### PR TITLE
Port tests to python 3

### DIFF
--- a/tests/twisted/cm/protocols.py
+++ b/tests/twisted/cm/protocols.py
@@ -18,7 +18,7 @@ def test(q, bus, conn, stream):
 
     protocols = cm_props.Get(cs.CM, 'Protocols')
     protocol_names = cm_iface.ListProtocols()
-    assertEquals(set(protocols.iterkeys()), set(protocol_names))
+    assertEquals(set(protocols.keys()), set(protocol_names))
 
     for name in protocol_names:
         props = protocols[name]

--- a/tests/twisted/connect/twice-to-same-account.py
+++ b/tests/twisted/connect/twice-to-same-account.py
@@ -28,7 +28,7 @@ def test(q, bus, conn, stream):
     # You might think that this is the test...
     try:
         cm_iface.RequestConnection('jabber', params)
-    except dbus.DBusException, e:
+    except dbus.DBusException as e:
         assertEquals(cs.NOT_AVAILABLE, e.get_dbus_name())
 
     # but you'd be wrong: we now test that Haze is still alive.

--- a/tests/twisted/gabbletest.py
+++ b/tests/twisted/gabbletest.py
@@ -233,7 +233,7 @@ class XmppAuthenticator(GabbleAuthenticator):
 
     def auth(self, auth):
         assert (base64.b64decode(bytes(auth)) ==
-            b'\x00%s\x00%s' % (self.username, self.password))
+            b'\x00%s\x00%s' % (self.username.encode(), self.password.encode()))
 
         success = domish.Element((ns.NS_XMPP_SASL, 'success'))
         self.xmlstream.send(success)
@@ -555,7 +555,7 @@ def disconnect_conn(q, conn, stream, expected_before=[], expected_after=[]):
     return before_events[:-2], after_events[:-1]
 
 def element_repr(element):
-    """__repr__ cannot safely return non-ASCII: see
+    r"""__repr__ cannot safely return non-ASCII: see
     <http://bugs.python.org/issue5876>. So we print non-ASCII characters as
     \uXXXX escapes in debug output
 

--- a/tests/twisted/roster/groups.py
+++ b/tests/twisted/roster/groups.py
@@ -104,8 +104,8 @@ def test(q, bus, conn, stream):
             EventPattern('dbus-return', method='AddToGroup'),
             )
     assertEquals('duncan@scotland.lit', iq.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq.stanza)}
     assertLength(2, groups)
     assertContains(default_group, groups)
     assertContains('Scots', groups)
@@ -121,8 +121,8 @@ def test(q, bus, conn, stream):
             EventPattern('dbus-return', method='RemoveFromGroup'),
             )
     assertEquals('duncan@scotland.lit', iq.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq.stanza)}
     assertLength(1, groups)
     assertContains('Scots', groups)
 
@@ -139,8 +139,8 @@ def test(q, bus, conn, stream):
             EventPattern('dbus-return', method='SetContactGroups'),
             )
     assertEquals('duncan@scotland.lit', iq.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq.stanza)}
     assertLength(2, groups)
     assertContains('Scots', groups)
     assertContains('Scottish former kings', groups)
@@ -149,8 +149,8 @@ def test(q, bus, conn, stream):
                 query_ns=ns.ROSTER),
             )
     assertEquals('duncan@scotland.lit', iq.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq.stanza)}
     assertLength(1, groups)
     assertContains('Scottish former kings', groups)
 
@@ -172,15 +172,15 @@ def test(q, bus, conn, stream):
             )
 
     assertEquals('romeo@montague.lit', iq1.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq1.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq1.stanza)}
     assertLength(2, groups)
     assertContains('Still alive', groups)
     assertContains(default_group, groups)
 
     assertEquals('romeo@montague.lit', iq2.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq2.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq2.stanza)}
     assertLength(1, groups)
     assertContains(default_group, groups)
 
@@ -195,8 +195,8 @@ def test(q, bus, conn, stream):
             EventPattern('dbus-return', method='SetGroupMembers'),
             )
     assertEquals('juliet@capulet.lit', iq.stanza.query.item['jid'])
-    groups = set([str(x) for x in xpath.queryForNodes('/iq/query/item/group',
-        iq.stanza)])
+    groups = {str(x) for x in xpath.queryForNodes('/iq/query/item/group',
+        iq.stanza)}
     assertLength(1, groups)
     assertContains('Capulets', groups)
 

--- a/tests/twisted/sasl/telepathy-password.py
+++ b/tests/twisted/sasl/telepathy-password.py
@@ -7,7 +7,7 @@ from hazetest import exec_test
 import constants as cs
 from saslutil import connect_and_get_sasl_channel
 
-PASSWORD = "pass"
+PASSWORD = b"pass"
 
 def test_close_straight_after_accept(q, bus, conn, stream):
     chan, props = connect_and_get_sasl_channel(q, bus, conn)

--- a/tests/twisted/servicetest.py
+++ b/tests/twisted/servicetest.py
@@ -4,9 +4,9 @@ Infrastructure code for testing connection managers.
 """
 from __future__ import print_function
 
-from twisted.internet import glib2reactor
+from twisted.internet import gireactor
 from twisted.internet.protocol import Protocol, Factory, ClientFactory
-glib2reactor.install()
+gireactor.install()
 import sys
 import time
 import os

--- a/tests/twisted/servicetest.py
+++ b/tests/twisted/servicetest.py
@@ -2,6 +2,7 @@
 """
 Infrastructure code for testing connection managers.
 """
+from __future__ import print_function
 
 from twisted.internet import glib2reactor
 from twisted.internet.protocol import Protocol, Factory, ClientFactory
@@ -88,7 +89,7 @@ class EventPattern:
         if event.type != self.type:
             return False
 
-        for key, value in self.properties.iteritems():
+        for key, value in self.properties.items():
             try:
                 if getattr(event, key) != value:
                     return False
@@ -130,7 +131,7 @@ class BaseEventQueue:
 
     def log(self, s):
         if self.verbose:
-            print s
+            print(s)
 
     def log_queues(self, queues):
         self.log ("Waiting for event on: %s" % ", ".join(queues))
@@ -139,7 +140,7 @@ class BaseEventQueue:
         self.log('got event:')
 
         if self.verbose:
-            map(self.log, format_event(event))
+            list(map(self.log, format_event(event)))
 
     def forbid_events(self, patterns):
         """
@@ -267,10 +268,10 @@ class BaseEventQueue:
 
     def queues_available(self, queues):
         if queues == None:
-            return self.event_queues.keys()
+            return list(self.event_queues.keys())
         else:
             available = self.event_queues.keys()
-            return filter(lambda x: x in available, queues)
+            return [x for x in queues if x in available]
 
 
     def pop_next(self, queue):
@@ -364,7 +365,7 @@ class EventQueueTest(unittest.TestCase):
         queue.append(Event('baz-test', x=1))
         queue.append(Event('baz-test', x=2))
 
-        for x in xrange(1,2):
+        for x in range(1,2):
             e = queue.expect ('baz-test')
             assertEquals (x, e.x)
 
@@ -392,18 +393,18 @@ def unwrap(x):
     printed."""
 
     if isinstance(x, list):
-        return map(unwrap, x)
+        return list(map(unwrap, x))
 
     if isinstance(x, tuple):
         return tuple(map(unwrap, x))
 
     if isinstance(x, dict):
-        return dict([(unwrap(k), unwrap(v)) for k, v in x.iteritems()])
+        return {unwrap(k): unwrap(v) for k, v in x.items()}
 
     if isinstance(x, dbus.Boolean):
         return bool(x)
 
-    for t in [unicode, str, long, int, float]:
+    for t in [str, bytes, int, int, float]:
         if isinstance(x, t):
             return t(x)
 
@@ -446,9 +447,9 @@ class ProxyWrapper:
         self.Properties = dbus.Interface(object, dbus.PROPERTIES_IFACE)
         self.TpProperties = \
             dbus.Interface(object, tp_name_prefix + '.Properties')
-        self.interfaces = dict([
-            (name, dbus.Interface(object, iface))
-            for name, iface in others.iteritems()])
+        self.interfaces = {
+            name: dbus.Interface(object, iface)
+            for name, iface in others.items()}
 
     def __getattr__(self, name):
         if name in self.interfaces:
@@ -501,9 +502,9 @@ def wrap_channel(chan, type_, extra=None):
         }
 
     if extra:
-        interfaces.update(dict([
-            (name, tp_name_prefix + '.Channel.Interface.' + name)
-            for name in extra]))
+        interfaces.update({
+            name: tp_name_prefix + '.Channel.Interface.' + name
+            for name in extra})
 
     return ProxyWrapper(chan, tp_name_prefix + '.Channel', interfaces)
 
@@ -512,9 +513,9 @@ def wrap_content(chan, extra=None):
     interfaces = { }
 
     if extra:
-        interfaces.update(dict([
-            (name, tp_name_prefix + '.Call1.Content.Interface.' + name)
-            for name in extra]))
+        interfaces.update({
+            name: tp_name_prefix + '.Call1.Content.Interface.' + name
+            for name in extra})
 
     return ProxyWrapper(chan, tp_name_prefix + '.Call1.Content', interfaces)
 
@@ -581,7 +582,7 @@ def watch_tube_signals(q, tube):
         q.append(Event('tube-signal',
             path=kwargs['path'],
             signal=kwargs['member'],
-            args=map(unwrap, args),
+            args=list(map(unwrap, args)),
             tube=tube))
 
     tube.add_signal_receiver(got_signal_cb,
@@ -677,7 +678,7 @@ def install_colourer():
 class DummyStream(object):
     def write(self, s):
         if 'CHECK_TWISTED_VERBOSE' in os.environ:
-            print s,
+            print(s, end=' ')
 
     def flush(self):
         pass

--- a/tools/c-constants-gen.py
+++ b/tools/c-constants-gen.py
@@ -17,7 +17,7 @@ class Generator(object):
         self.do_footer()
 
     def write(self, code):
-        stdout.write(code.encode('utf-8'))
+        stdout.write(code)
 
     # Header
     def do_header(self):

--- a/tools/glib-ginterface-gen.py
+++ b/tools/glib-ginterface-gen.py
@@ -26,7 +26,7 @@ import sys
 import os.path
 import xml.dom.minidom
 
-from libglibcodegen import Signature, type_to_gtype, cmp_by_name, \
+from libglibcodegen import Signature, type_to_gtype, key_by_name, \
         NS_TP, dbus_gutils_wincaps_to_uscore, \
         signal_to_marshal_name, method_to_glue_marshal_name
 
@@ -694,8 +694,7 @@ class Generator(object):
         return False
 
     def __call__(self):
-        nodes = self.dom.getElementsByTagName('node')
-        nodes.sort(cmp_by_name)
+        nodes = sorted(self.dom.getElementsByTagName('node'), key=key_by_name)
 
         self.h('#include <glib-object.h>')
         self.h('#include <dbus/dbus-glib.h>')
@@ -730,7 +729,7 @@ class Generator(object):
 
 
 def cmdline_error():
-    print """\
+    print("""\
 usage:
     gen-ginterface [OPTIONS] xmlfile Prefix_
 options:
@@ -750,7 +749,7 @@ options:
             void symbol (DBusGMethodInvocation *context)
         and return some sort of "not implemented" error via
             dbus_g_method_return_error (context, ...)
-"""
+""")
     sys.exit(1)
 
 

--- a/tools/glib-interfaces-gen.py
+++ b/tools/glib-interfaces-gen.py
@@ -14,10 +14,10 @@ class Generator(object):
         self.spec = get_by_path(dom, "spec")[0]
 
     def h(self, code):
-        self.decls.write(code.encode('utf-8'))
+        self.decls.write(code)
 
     def c(self, code):
-        self.impls.write(code.encode('utf-8'))
+        self.impls.write(code)
 
     def __call__(self):
         for f in self.h, self.c:

--- a/tools/glib-signals-marshal-gen.py
+++ b/tools/glib-signals-marshal-gen.py
@@ -41,12 +41,9 @@ class Generator(object):
         for signal in signals:
             self.do_signal(signal)
 
-        all = self.marshallers.keys()
-        all.sort()
-        for marshaller in all:
-            rhs = self.marshallers[marshaller]
+        for marshaller, rhs in sorted(self.marshallers.items()):
             if not marshaller.startswith('g_cclosure'):
-                print 'VOID:' + ','.join(rhs)
+                print('VOID:' + ','.join(rhs))
 
 if __name__ == '__main__':
     argv = sys.argv[1:]

--- a/tools/libglibcodegen.py
+++ b/tools/libglibcodegen.py
@@ -23,7 +23,7 @@ please make any changes there.
 
 from libtpcodegen import NS_TP, \
                          Signature, \
-                         cmp_by_name, \
+                         key_by_name, \
                          escape_as_identifier, \
                          get_by_path, \
                          get_descendant_text, \
@@ -154,7 +154,7 @@ def type_to_gtype(s):
         return ("GHashTable *", "DBUS_TYPE_G_STRING_STRING_HASHTABLE", "BOXED", False)
     elif s[:2] == 'a{':  #some arbitrary hash tables
         if s[2] not in ('y', 'b', 'n', 'q', 'i', 'u', 's', 'o', 'g'):
-            raise Exception, "can't index a hashtable off non-basic type " + s
+            raise Exception("can't index a hashtable off non-basic type " + s)
         first = type_to_gtype(s[2])
         second = type_to_gtype(s[3:-1])
         return ("GHashTable *", "(dbus_g_type_get_map (\"GHashTable\", " + first[1] + ", " + second[1] + "))", "BOXED", False)
@@ -169,4 +169,4 @@ def type_to_gtype(s):
         return ("GValueArray *", gtype, "BOXED", True)
 
     # we just don't know ..
-    raise Exception, "don't know the GType for " + s
+    raise Exception("don't know the GType for " + s)

--- a/tools/libtpcodegen.py
+++ b/tools/libtpcodegen.py
@@ -29,9 +29,8 @@ NS_TP = "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
 _ASCII_ALNUM = ascii_letters + digits
 
 
-def cmp_by_name(node1, node2):
-    return cmp(node1.getAttributeNode("name").nodeValue,
-               node2.getAttributeNode("name").nodeValue)
+def key_by_name(node):
+    return node.getAttributeNode("name").nodeValue
 
 
 def escape_as_identifier(identifier):
@@ -155,7 +154,7 @@ class _SignatureIter:
     def __init__(self, string):
         self.remaining = string
 
-    def next(self):
+    def __next__(self):
         if self.remaining == '':
             raise StopIteration
 
@@ -200,6 +199,7 @@ class _SignatureIter:
         end = end + 1
         self.remaining = signature[end:]
         return Signature(signature[0:end])
+    next = __next__
 
 
 class Signature(str):

--- a/tools/make-release-mail.py
+++ b/tools/make-release-mail.py
@@ -19,8 +19,8 @@ def extract_description(package, version, news_path):
                 break
 
         # Skip the ====== line, and the first blank line
-        lines.next()
-        lines.next()
+        next(lines)
+        next(lines)
 
         got_release_name = False
 
@@ -50,7 +50,7 @@ GIT_URL = 'http://cgit.freedesktop.org/telepathy'
 def main(package, version, news_path):
     release_name, details = extract_description(package, version, news_path)
 
-    print """
+    print("""
 %(release_name)s
 
 tarball: %(base_url)s/%(package)s/%(package)s-%(version)s.tar.gz
@@ -64,14 +64,14 @@ git: %(git_url)s/%(package)s
         'version': version,
         'release_name': release_name,
         'details': details,
-    }
+    })
 
 if __name__ == '__main__':
     try:
         package, version, news_path = sys.argv[1:]
 
         main(package, version, news_path)
-    except ValueError, e:
+    except ValueError as e:
         sys.stderr.write(
             'Usage: %s package-name package.version.number path/to/NEWS\n' %
             sys.argv[0])


### PR DESCRIPTION
This PR is a basic port to python 3 (retaining compatibility wherever possible), tests work with twisted/twisted#1145 applied.

Please consider merging, as distros are deleting telepathy-haze only because its tests are in python 2 only.
https://bugs.gentoo.org/714636
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=938639
https://bugzilla.redhat.com/show_bug.cgi?id=1676130